### PR TITLE
Make butlerbot also join #jenkins-meeting

### DIFF
--- a/butlerbot/butlerbot.conf.erb
+++ b/butlerbot/butlerbot.conf.erb
@@ -70,7 +70,7 @@ supybot.networks.freenode.servers: irc.freenode.net:6667
 #
 # Default value:  
 ###
-supybot.networks.freenode.channels: #jenkins
+supybot.networks.freenode.channels: #jenkins-meeting #jenkins
 
 ###
 # Determines what key (if any) will be used to join the channel.


### PR DESCRIPTION
Tested manually.

---

Some notes from testing the bot and this change:
- `robobutler-test` does not have an account with NickServ (anymore?) with the specified credentials, or otherwise failed to authenticate
- I had to add `RUN apt-get update` before `apt-get install` found `supybot`
- There seems to be a mismatch in the log directories configration as I wrote [here](https://github.com/jenkins-infra/robobutler/commit/e0482c7577792401924794a745acf098b9371f67)
